### PR TITLE
add first transformation tests

### DIFF
--- a/src/linse/transform.py
+++ b/src/linse/transform.py
@@ -1,0 +1,48 @@
+from linse.annotate import soundclass
+from linse.typedsequence import ints
+
+def resegment(tokens, sep='+'):
+    """
+    Resegmentation of a sequence based on a segmentation character.
+
+    :param tokens: the input sequence
+    :param separator: a character or a list of characters
+
+    :returns: a list of tokens, which conform to the *type*
+    """
+    out = [[]]
+    for token in tokens:
+        if token in sep:
+            out += [[]]
+        else:
+            out[-1] += [token]
+    return [part for part in out if part]
+
+
+def syllabify(tokens, sep='+', vowels=2):
+    """
+    Find syllable breakpoints for a set of tokens, based on their prosody.
+
+    :param tokens: input sequence
+    :param sep: separator
+    :param vowels: indicate after how many vowels in a row it should split
+    """
+    out = []
+    prosodies = ints(soundclass(tokens, 'art'))
+    tuples = [('#', 0)]+list(zip(tokens, prosodies))+[('$', 0)]
+    vowel = 0
+    for i, (tok, pro) in enumerate(tuples[1:-1], start=1):
+        ptok, ppro = tuples[i-1]
+        ftok, fpro = tuples[i+1]
+        if pro == 7:
+            vowel += 1
+        if fpro != 8:
+            if ppro >= pro < fpro and vowel:
+                out += [sep]
+                vowel = 0
+            elif vowel > vowels and pro == 7:
+                out += [sep]
+        out += [tok]
+    return out
+        
+    

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,29 @@
+import pytest
+from linse import transform
+
+
+@pytest.mark.parametrize(
+    'seq,res',
+    [
+        ('t a ŋ ⁵ + ts ai t', ['t a ŋ ⁵', 'ts ai t']),
+        ('k u n + d e', ['k u n', 'd e']),
+        ('+ k i n + d e r +', ['k i n', 'd e r'])
+    ]
+)
+def test_resegment(seq, res):
+    assert transform.resegment(
+            seq.split()) == [p.split() for p in res]
+
+
+
+@pytest.mark.parametrize(
+    'seq,res,vowels',
+    [
+        ('f a ŋ ⁵ m e i', 'f a ŋ ⁵ + m e i', 2),
+        ('m a n t a', 'm a n + t a', 2),
+        ('m a o a', 'm a + o + a', 1),
+        ('h e r b s t g e w i t t e r', 'h e r + b s t g e + w i t + t e r', 2)
+    ]
+)
+def test_syllabify(seq, res, vowels):
+    assert ' '.join(transform.syllabify(seq.split(), vowels=vowels)) == res


### PR DESCRIPTION
this adds two functions, one utility function (resegment) which helps to split a sequence according a split symbol (or a list of symbols), and a function to syllabify. Note that the syllabification yields not perfect results, since it follows prosody, plus one new criterion: each syllable needs one vowel, so if a seqeunce has no identifiable vowel, it won't be treated as a syllable. As aresult:

```python
>>> ' '.join(transform.syllabify(list('herbstgewitter')))
'h e r + b s t g e + w i t + t e r'
```
But since there is no real criterion apart from the morpheme boundary,  I think we can live with it.
