### PR TITLE
fix asjp problem

### DIFF
--- a/src/linse/segment.py
+++ b/src/linse/segment.py
@@ -221,6 +221,8 @@ def asjp(word, merge_vowels=True):
             merge_vowels=merge_vowels
         )
     )
+    # patch from Wichmann's paper
+    tokens = re.sub(r'(["\*])([~\$])', r'\2\1', tokens)
     tokens = re.sub(r'([^ ]) ([^ ])~', r'\1\2~', tokens)
     tokens = re.sub(r'([^ ]) ([^ ]) ([^ ])\$', r'\1\2\3$', tokens)
     return tokens.split(' ')

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -39,6 +39,8 @@ def test_ipa(text, kw, seq):
         ('', []),
         ("tj~ut", ["tj~", "u", "t"]),
         ("kwh$ark", ["kwh$", "a", "r", "k"]),
+        ('kwh"$ark', ['kwh$"', "a", "r", "k"]),
+        ('kw*~ark', ['kw~*', 'a', 'r', 'k']) 
     ]
 )
 def test_asjp(text, seq):


### PR DESCRIPTION
There is a paper by Wichmann et al, where they use and complain about lingpy's asjp2tokens function, as it seems to not allow for something I consider problematic:

https://github.com/EL-CL/temperature-sonority/blob/ed0599798ba798be1c5d62ad30730f8787414d63/sonority_index_lib.py#L43C1-L49C2

So this fix addresses this problem, but it shows to me only that the whole ASJP enterprise is based on too many inconsistencies.